### PR TITLE
Handle Core Data delete failure in MealsView

### DIFF
--- a/MealTrackerApp/MealTrackerApp/MealsView.swift
+++ b/MealTrackerApp/MealTrackerApp/MealsView.swift
@@ -12,6 +12,8 @@ struct MealsView: View {
 
     @State private var showingAddMeal = false
     @State private var selectedMealForEdit: Meal? = nil
+    @State private var showDeleteError = false
+    @State private var deleteErrorMessage = ""
 
     var body: some View {
         NavigationView {
@@ -86,6 +88,11 @@ struct MealsView: View {
                         .environment(\.managedObjectContext, viewContext)
                 }
             }
+            .alert("Error", isPresented: $showDeleteError) {
+                Button("OK", role: .cancel) { }
+            } message: {
+                Text(deleteErrorMessage)
+            }
         }
     }
 
@@ -94,7 +101,13 @@ struct MealsView: View {
             let meal = meals[index]
             viewContext.delete(meal)
         }
-        try? viewContext.save()
+        do {
+            try viewContext.save()
+        } catch {
+            deleteErrorMessage = "Failed to delete meal: \(error.localizedDescription)"
+            showDeleteError = true
+            print(deleteErrorMessage)
+        }
     }
 
     private func mealTotalCalories(_ meal: Meal) -> Double {


### PR DESCRIPTION
## Summary
- add state to track Core Data delete errors
- show an alert and log when saving the context fails during meal deletion

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -project MealTrackerApp/MealTrackerApp.xcodeproj -scheme MealTrackerApp -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14' build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f788f0a248324b9ca0088c29e5128