### PR TITLE
Replace NavigationView with NavigationStack

### DIFF
--- a/MealTrackerApp/MealTrackerApp/AddMealView.swift
+++ b/MealTrackerApp/MealTrackerApp/AddMealView.swift
@@ -27,7 +27,7 @@ struct AddMealView: View {
     ) private var ingredients: FetchedResults<Ingredient>
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             Form {
                 Section(header: Text("Meal Info")) {
                     TextField("Meal name", text: $name)
@@ -110,9 +110,13 @@ struct AddMealView: View {
                 .disabled(name.isEmpty || selectedIngredients.isEmpty)
             }
             .navigationTitle(editMeal == nil ? "Add Meal" : "Edit Meal")
-            .navigationBarItems(trailing: Button("Cancel") {
-                dismiss()
-            })
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+            }
             .onAppear {
                 if let meal = editMeal {
                     preloadMeal(meal)

--- a/MealTrackerApp/MealTrackerApp/MealsView.swift
+++ b/MealTrackerApp/MealTrackerApp/MealsView.swift
@@ -14,7 +14,7 @@ struct MealsView: View {
     @State private var selectedMealForEdit: Meal? = nil
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ZStack(alignment: .bottomLeading) {
                 List {
                     ForEach(meals) { meal in
@@ -81,7 +81,7 @@ struct MealsView: View {
                 }
             }
             .sheet(isPresented: $showingAddMeal) {
-                NavigationView {
+                NavigationStack {
                     AddMealView(editMeal: selectedMealForEdit)
                         .environment(\.managedObjectContext, viewContext)
                 }


### PR DESCRIPTION
## Summary
- Migrate MealsView and AddMealView from `NavigationView` to `NavigationStack`
- Update AddMealView to use `toolbar` for its cancel button

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688f78979d1483248af8472ba98fe756