### PR TITLE
Add macronutrient and metadata fields to Ingredient model

### DIFF
--- a/MealTrackerApp/MealTrackerApp/AddIngredientView.swift
+++ b/MealTrackerApp/MealTrackerApp/AddIngredientView.swift
@@ -15,6 +15,14 @@ struct AddIngredientView: View {
     @State private var selectedImage: PhotosPickerItem?
     @State private var imageData: Data?
 
+    @State private var protein: String = ""
+    @State private var fat: String = ""
+    @State private var carbs: String = ""
+    @State private var fiber: String = ""
+    @State private var servingSize: String = ""
+    @State private var brand: String = ""
+    @State private var upc: String = ""
+
     @State private var showAlert = false
     @State private var alertMessage = ""
 
@@ -60,6 +68,23 @@ struct AddIngredientView: View {
                     TextEditor(text: $nutritionFacts)
                         .frame(height: 100)
                         .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.gray.opacity(0.3)))
+                }
+
+                Section(header: Text("Macros (optional)")) {
+                    TextField("Protein (g)", text: $protein)
+                        .keyboardType(.decimalPad)
+                    TextField("Fat (g)", text: $fat)
+                        .keyboardType(.decimalPad)
+                    TextField("Carbs (g)", text: $carbs)
+                        .keyboardType(.decimalPad)
+                    TextField("Fiber (g)", text: $fiber)
+                        .keyboardType(.decimalPad)
+                }
+
+                Section(header: Text("Additional Info (optional)")) {
+                    TextField("Serving Size", text: $servingSize)
+                    TextField("Brand", text: $brand)
+                    TextField("UPC", text: $upc)
                 }
 
                 Section(header: Text("Image (optional)")) {
@@ -120,6 +145,13 @@ struct AddIngredientView: View {
                     foodType = ing.foodType ?? "Other"
                     nutritionFacts = ing.nutritionFacts ?? ""
                     imageData = ing.image
+                    protein = ing.protein == 0 ? "" : String(format: "%.1f", ing.protein)
+                    fat = ing.fat == 0 ? "" : String(format: "%.1f", ing.fat)
+                    carbs = ing.carbs == 0 ? "" : String(format: "%.1f", ing.carbs)
+                    fiber = ing.fiber == 0 ? "" : String(format: "%.1f", ing.fiber)
+                    servingSize = ing.servingSize ?? ""
+                    brand = ing.brand ?? ""
+                    upc = ing.upc ?? ""
                 }
             }
         }
@@ -149,6 +181,13 @@ struct AddIngredientView: View {
         ingredient.standardUnit = standardUnit
         ingredient.foodType = foodType
         ingredient.nutritionFacts = nutritionFacts
+        ingredient.protein = Double(protein) ?? 0
+        ingredient.fat = Double(fat) ?? 0
+        ingredient.carbs = Double(carbs) ?? 0
+        ingredient.fiber = Double(fiber) ?? 0
+        ingredient.servingSize = servingSize.isEmpty ? nil : servingSize
+        ingredient.brand = brand.isEmpty ? nil : brand
+        ingredient.upc = upc.isEmpty ? nil : upc
         if let data = imageData, let image = UIImage(data: data) {
             ingredient.image = image.resized(to: CGSize(width: 300, height: 300), compressionQuality: 0.7)
         } else {

--- a/MealTrackerApp/MealTrackerApp/Ingredient+CoreDataClass.swift
+++ b/MealTrackerApp/MealTrackerApp/Ingredient+CoreDataClass.swift
@@ -1,0 +1,7 @@
+import Foundation
+import CoreData
+
+@objc(Ingredient)
+public class Ingredient: NSManagedObject {
+}
+

--- a/MealTrackerApp/MealTrackerApp/Ingredient+CoreDataProperties.swift
+++ b/MealTrackerApp/MealTrackerApp/Ingredient+CoreDataProperties.swift
@@ -1,0 +1,45 @@
+import Foundation
+import CoreData
+
+extension Ingredient {
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Ingredient> {
+        return NSFetchRequest<Ingredient>(entityName: "Ingredient")
+    }
+
+    @NSManaged public var calories: Double
+    @NSManaged public var caloriesPerUnit: Double
+    @NSManaged public var foodType: String?
+    @NSManaged public var image: Data?
+    @NSManaged public var name: String?
+    @NSManaged public var nutritionFacts: String?
+    @NSManaged public var quantityType: String?
+    @NSManaged public var standardQuantity: Double
+    @NSManaged public var standardUnit: String?
+    @NSManaged public var unit: String?
+    @NSManaged public var protein: Double
+    @NSManaged public var fat: Double
+    @NSManaged public var carbs: Double
+    @NSManaged public var fiber: Double
+    @NSManaged public var servingSize: String?
+    @NSManaged public var brand: String?
+    @NSManaged public var upc: String?
+    @NSManaged public var mealIngredients: NSSet?
+}
+
+// MARK: Generated accessors for mealIngredients
+extension Ingredient {
+    @objc(addMealIngredientsObject:)
+    @NSManaged public func addToMealIngredients(_ value: MealIngredient)
+
+    @objc(removeMealIngredientsObject:)
+    @NSManaged public func removeFromMealIngredients(_ value: MealIngredient)
+
+    @objc(addMealIngredients:)
+    @NSManaged public func addToMealIngredients(_ values: NSSet)
+
+    @objc(removeMealIngredients:)
+    @NSManaged public func removeFromMealIngredients(_ values: NSSet)
+}
+
+extension Ingredient: Identifiable {}
+

--- a/MealTrackerApp/MealTrackerApp/IngredientsView.swift
+++ b/MealTrackerApp/MealTrackerApp/IngredientsView.swift
@@ -32,9 +32,15 @@ struct IngredientsView: View {
                         VStack(alignment: .leading) {
                             Text(ingredient.name ?? "Unnamed")
                                 .font(.headline)
-                            Text(ingredient.foodType ?? "Unknown")
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
+                            if let brand = ingredient.brand, !brand.isEmpty {
+                                Text(brand)
+                                    .font(.subheadline)
+                                    .foregroundColor(.secondary)
+                            } else {
+                                Text(ingredient.foodType ?? "Unknown")
+                                    .font(.subheadline)
+                                    .foregroundColor(.secondary)
+                            }
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
                     }

--- a/MealTrackerApp/MealTrackerApp/MealTrackerApp.xcdatamodeld/MealTrackerApp.xcdatamodel/contents
+++ b/MealTrackerApp/MealTrackerApp/MealTrackerApp.xcdatamodeld/MealTrackerApp.xcdatamodel/contents
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24F74" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Entity" representedClassName="Entity" syncable="YES" codeGenerationType="class"/>
-    <entity name="Ingredient" representedClassName="Ingredient" syncable="YES" codeGenerationType="class">
+    <entity name="Ingredient" representedClassName="Ingredient" syncable="YES" codeGenerationType="manual/none">
         <attribute name="calories" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="caloriesPerUnit" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="foodType" optional="YES" attributeType="String"/>
@@ -12,6 +12,13 @@
         <attribute name="standardQuantity" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="standardUnit" optional="YES" attributeType="String"/>
         <attribute name="unit" optional="YES" attributeType="String"/>
+        <attribute name="protein" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
+        <attribute name="fat" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
+        <attribute name="carbs" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
+        <attribute name="fiber" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
+        <attribute name="servingSize" optional="YES" attributeType="String"/>
+        <attribute name="brand" optional="YES" attributeType="String"/>
+        <attribute name="upc" optional="YES" attributeType="String"/>
         <relationship name="mealIngredients" toMany="YES" deletionRule="Nullify" destinationEntity="MealIngredient" inverseName="ingredient" inverseEntity="MealIngredient"/>
     </entity>
     <entity name="Meal" representedClassName=".Meal" syncable="YES" codeGenerationType="class">


### PR DESCRIPTION
## Summary
- extend Core Data model with macronutrient and metadata attributes for `Ingredient`
- regenerate `Ingredient` NSManagedObject subclass and surface new fields in UI
- show brand information in ingredient list

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689261e40094832492167543ab39619d